### PR TITLE
handle multiple used spdlog_ros logging managers and include package name in logger name

### DIFF
--- a/include/spdlog_ros/logger_manager.hpp
+++ b/include/spdlog_ros/logger_manager.hpp
@@ -38,7 +38,16 @@ public:
   LoggerManager(const LoggerManager& other) = delete;
   LoggerManager& operator=(const LoggerManager& other) = delete;
 
-  static void CreateLoggerManager(const std::string& root_logger_name);
+  /**
+   * @brief Initializes the singleton Logger Manager with a base name
+   * 
+   * @note The log file name replaces slashes and dots in the base name with underscores
+   *       and prepends the current date and time. Multiple calls have no effect after
+   *       the first initialization.
+   *
+   * @param base_logger_name The base logger name
+   */
+  static void CreateLoggerManager(const std::string& base_logger_name);
 
   static std::shared_ptr<LoggerManager> GetLoggerManager();
 
@@ -66,7 +75,7 @@ public:
   void checkLogLocationEnabled(LoggerLocation* logger_status, const std::string& name);
 
 private:
-  LoggerManager(const std::string& root_logger_name);
+  LoggerManager(const std::string& base_logger_name);
 
   std::string getFullLoggerName(const std::string& name);
 
@@ -78,7 +87,7 @@ private:
 
   static std::shared_ptr<LoggerManager> instance_;
 
-  std::string root_logger_name_ = "";
+  std::string base_logger_name_ = "";
 
   std::vector<spdlog::sink_ptr> default_sinks_;
 

--- a/include/spdlog_ros/logging_macros.hpp
+++ b/include/spdlog_ros/logging_macros.hpp
@@ -156,7 +156,7 @@
  * Setup the logging status and update if required
  * This ensures that checking the log level is extremely cheap by just checking then outside if 
  * __spdlog_ros_logging_enabled_log_location.enabled is true
- * \param name The name of the logger (without the root logger name)
+ * \param name The name of the logger (without the base logger name)
  * \param severity The severity of the logging as spdlog::level::level_enum
  */
 #define SPDLOG_ROS_LOGGING_ENABLED(name, severity) \
@@ -236,11 +236,11 @@
  */
 #define SPDLOG_ROS_GENERAL(severity, ...) \
   do { \
-    SPDLOG_ROS_LOGGING_ENABLED("", severity) \
+    SPDLOG_ROS_LOGGING_ENABLED(SPDLOG_ROS_DEFAULT_NAME, severity) \
     if (SPDLOG_ROS_UTILS_UNLIKELY(__spdlog_ros_logging_enabled_log_location.enabled)) \
     { \
       SPDLOG_ROS_UTILS_LOG( \
-        "", \
+        SPDLOG_ROS_DEFAULT_NAME, \
         severity, \
         __VA_ARGS__); \
     } \
@@ -259,11 +259,11 @@
  */
 #define SPDLOG_ROS_GENERAL_ONCE(severity, ...) \
   do { \
-    SPDLOG_ROS_LOGGING_ENABLED("", severity) \
+    SPDLOG_ROS_LOGGING_ENABLED(SPDLOG_ROS_DEFAULT_NAME, severity) \
     if (SPDLOG_ROS_UTILS_UNLIKELY(__spdlog_ros_logging_enabled_log_location.enabled)) \
     { \
       SPDLOG_ROS_UTILS_LOG_ONCE(     \
-        "", \
+        SPDLOG_ROS_DEFAULT_NAME, \
         severity, \
         __VA_ARGS__); \
     } \
@@ -283,11 +283,11 @@
  */
 #define SPDLOG_ROS_GENERAL_EXPRESSION(severity, expression, ...) \
   do { \
-    SPDLOG_ROS_LOGGING_ENABLED("", severity) \
+    SPDLOG_ROS_LOGGING_ENABLED(SPDLOG_ROS_DEFAULT_NAME, severity) \
     if (SPDLOG_ROS_UTILS_UNLIKELY(__spdlog_ros_logging_enabled_log_location.enabled)) \
     { \
       SPDLOG_ROS_UTILS_LOG_EXPRESSION( \
-        "", \
+        SPDLOG_ROS_DEFAULT_NAME, \
         severity, \
         expression, \
         __VA_ARGS__); \
@@ -308,11 +308,11 @@
  */
 #define SPDLOG_ROS_GENERAL_FUNCTION(severity, function, ...) \
   do { \
-    SPDLOG_ROS_LOGGING_ENABLED("", severity) \
+    SPDLOG_ROS_LOGGING_ENABLED(SPDLOG_ROS_DEFAULT_NAME, severity) \
     if (SPDLOG_ROS_UTILS_UNLIKELY(__spdlog_ros_logging_enabled_log_location.enabled)) \
     { \
       SPDLOG_ROS_UTILS_LOG_FUNCTION( \
-        "", \
+        SPDLOG_ROS_DEFAULT_NAME, \
         severity, \
         function, \
         __VA_ARGS__); \
@@ -332,11 +332,11 @@
  */
 #define SPDLOG_ROS_GENERAL_SKIPFIRST(severity, ...) \
   do { \
-    SPDLOG_ROS_LOGGING_ENABLED("", severity) \
+    SPDLOG_ROS_LOGGING_ENABLED(SPDLOG_ROS_DEFAULT_NAME, severity) \
     if (SPDLOG_ROS_UTILS_UNLIKELY(__spdlog_ros_logging_enabled_log_location.enabled)) \
     { \
       SPDLOG_ROS_UTILS_LOG_SKIPFIRST( \
-        "", \
+        SPDLOG_ROS_DEFAULT_NAME, \
         severity, \
         __VA_ARGS__); \
     } \
@@ -356,11 +356,11 @@
  */
 #define SPDLOG_ROS_GENERAL_THROTTLE(severity, duration, ...) \
   do { \
-    SPDLOG_ROS_LOGGING_ENABLED("", severity) \
+    SPDLOG_ROS_LOGGING_ENABLED(SPDLOG_ROS_DEFAULT_NAME, severity) \
     if (SPDLOG_ROS_UTILS_UNLIKELY(__spdlog_ros_logging_enabled_log_location.enabled)) \
     { \
       SPDLOG_ROS_UTILS_LOG_THROTTLE( \
-        "", \
+        SPDLOG_ROS_DEFAULT_NAME, \
         severity, \
         spdlog_ros::LoggerManager::GetLoggerManager()->getTimePointCallback(), \
         duration, \
@@ -383,11 +383,11 @@
  */
 #define SPDLOG_ROS_GENERAL_SKIPFIRST_THROTTLE(severity, duration, ...) \
   do { \
-    SPDLOG_ROS_LOGGING_ENABLED("", severity) \
+    SPDLOG_ROS_LOGGING_ENABLED(SPDLOG_ROS_DEFAULT_NAME, severity) \
     if (SPDLOG_ROS_UTILS_UNLIKELY(__spdlog_ros_logging_enabled_log_location.enabled)) \
     { \
       SPDLOG_ROS_UTILS_LOG_SKIPFIRST_THROTTLE( \
-        "", \
+        SPDLOG_ROS_DEFAULT_NAME, \
         severity, \
         spdlog_ros::LoggerManager::GetLoggerManager()->getTimePointCallback(), \
         duration, \
@@ -406,13 +406,13 @@
  */
 #define SPDLOG_ROS_GENERAL_STREAM(severity, stream_arg) \
   do { \
-    SPDLOG_ROS_LOGGING_ENABLED("", severity) \
+    SPDLOG_ROS_LOGGING_ENABLED(SPDLOG_ROS_DEFAULT_NAME, severity) \
     if (SPDLOG_ROS_UTILS_UNLIKELY(__spdlog_ros_logging_enabled_log_location.enabled)) \
     { \
       std::stringstream spllog_ros_stream_ss_; \
       spllog_ros_stream_ss_ << stream_arg; \
       SPDLOG_ROS_UTILS_LOG(                   \
-        "", \
+        SPDLOG_ROS_DEFAULT_NAME, \
         severity, \
         "{}", spllog_ros_stream_ss_.str().c_str()); \
     } \
@@ -430,13 +430,13 @@
  */
 #define SPDLOG_ROS_GENERAL_STREAM_NAMED(severity, name, stream_arg) \
   do { \
-    SPDLOG_ROS_LOGGING_ENABLED(name, severity) \
+    SPDLOG_ROS_LOGGING_ENABLED(SPDLOG_ROS_NAMED_LOGGER_NAME(name), severity) \
     if (SPDLOG_ROS_UTILS_UNLIKELY(__spdlog_ros_logging_enabled_log_location.enabled)) \
     { \
       std::stringstream spllog_ros_stream_ss_; \
       spllog_ros_stream_ss_ << stream_arg; \
       SPDLOG_ROS_UTILS_LOG(                   \
-        name, \
+        SPDLOG_ROS_NAMED_LOGGER_NAME(name), \
         severity, \
         "{}", spllog_ros_stream_ss_.str().c_str()); \
     } \
@@ -454,13 +454,13 @@
  */
 #define SPDLOG_ROS_GENERAL_STREAM_ONCE(severity, stream_arg) \
   do { \
-    SPDLOG_ROS_LOGGING_ENABLED("", severity) \
+    SPDLOG_ROS_LOGGING_ENABLED(SPDLOG_ROS_DEFAULT_NAME, severity) \
     if (SPDLOG_ROS_UTILS_UNLIKELY(__spdlog_ros_logging_enabled_log_location.enabled)) \
     { \
       std::stringstream spllog_ros_stream_ss_; \
       spllog_ros_stream_ss_ << stream_arg; \
       SPDLOG_ROS_UTILS_LOG_ONCE( \
-        "", \
+        SPDLOG_ROS_DEFAULT_NAME, \
         severity, \
         "{}", spllog_ros_stream_ss_.str().c_str()); \
     } \
@@ -479,13 +479,13 @@
  */
 #define SPDLOG_ROS_GENERAL_STREAM_ONCE_NAMED(severity, name, stream_arg) \
   do { \
-    SPDLOG_ROS_LOGGING_ENABLED(name, severity) \
+    SPDLOG_ROS_LOGGING_ENABLED(SPDLOG_ROS_NAMED_LOGGER_NAME(name), severity) \
     if (SPDLOG_ROS_UTILS_UNLIKELY(__spdlog_ros_logging_enabled_log_location.enabled)) \
     { \
       std::stringstream spllog_ros_stream_ss_; \
       spllog_ros_stream_ss_ << stream_arg; \
       SPDLOG_ROS_UTILS_LOG_ONCE( \
-        name, \
+        SPDLOG_ROS_NAMED_LOGGER_NAME(name), \
         severity, \
         "{}", spllog_ros_stream_ss_.str().c_str()); \
     } \
@@ -504,13 +504,13 @@
  */
 #define SPDLOG_ROS_GENERAL_STREAM_EXPRESSION(severity, expression, stream_arg) \
   do { \
-    SPDLOG_ROS_LOGGING_ENABLED("", severity) \
+    SPDLOG_ROS_LOGGING_ENABLED(SPDLOG_ROS_DEFAULT_NAME, severity) \
     if (SPDLOG_ROS_UTILS_UNLIKELY(__spdlog_ros_logging_enabled_log_location.enabled)) \
     { \
       std::stringstream spllog_ros_stream_ss_; \
       spllog_ros_stream_ss_ << stream_arg; \
       SPDLOG_ROS_UTILS_LOG_EXPRESSION( \
-        "", \
+        SPDLOG_ROS_DEFAULT_NAME, \
         severity, \
         expression, \
         "{}", spllog_ros_stream_ss_.str().c_str()); \
@@ -531,13 +531,13 @@
  */
 #define SPDLOG_ROS_GENERAL_STREAM_EXPRESSION_NAMED(severity, expression, name, stream_arg) \
   do { \
-    SPDLOG_ROS_LOGGING_ENABLED(name, severity) \
+    SPDLOG_ROS_LOGGING_ENABLED(SPDLOG_ROS_NAMED_LOGGER_NAME(name), severity) \
     if (SPDLOG_ROS_UTILS_UNLIKELY(__spdlog_ros_logging_enabled_log_location.enabled)) \
     { \
       std::stringstream spllog_ros_stream_ss_; \
       spllog_ros_stream_ss_ << stream_arg; \
       SPDLOG_ROS_UTILS_LOG_EXPRESSION( \
-        name, \
+        SPDLOG_ROS_NAMED_LOGGER_NAME(name), \
         severity, \
         expression, \
         "{}", spllog_ros_stream_ss_.str().c_str()); \
@@ -557,13 +557,13 @@
  */
 #define SPDLOG_ROS_GENERAL_STREAM_FUNCTION(severity, function, stream_arg) \
   do { \
-    SPDLOG_ROS_LOGGING_ENABLED("", severity) \
+    SPDLOG_ROS_LOGGING_ENABLED(SPDLOG_ROS_DEFAULT_NAME, severity) \
     if (SPDLOG_ROS_UTILS_UNLIKELY(__spdlog_ros_logging_enabled_log_location.enabled)) \
     { \
       std::stringstream spllog_ros_stream_ss_; \
       spllog_ros_stream_ss_ << stream_arg; \
       SPDLOG_ROS_UTILS_LOG_FUNCTION( \
-        "", \
+        SPDLOG_ROS_DEFAULT_NAME, \
         severity, \
         function, \
         "{}", spllog_ros_stream_ss_.str().c_str()); \
@@ -584,13 +584,13 @@
  */
 #define SPDLOG_ROS_GENERAL_STREAM_FUNCTION_NAMED(severity, function, name, stream_arg) \
   do { \
-    SPDLOG_ROS_LOGGING_ENABLED(name, severity) \
+    SPDLOG_ROS_LOGGING_ENABLED(SPDLOG_ROS_NAMED_LOGGER_NAME(name), severity) \
     if (SPDLOG_ROS_UTILS_UNLIKELY(__spdlog_ros_logging_enabled_log_location.enabled)) \
     { \
       std::stringstream spllog_ros_stream_ss_; \
       spllog_ros_stream_ss_ << stream_arg; \
       SPDLOG_ROS_UTILS_LOG_FUNCTION( \
-        name, \
+        SPDLOG_ROS_NAMED_LOGGER_NAME(name), \
         severity, \
         function, \
         "{}", spllog_ros_stream_ss_.str().c_str()); \
@@ -609,13 +609,13 @@
  */
 #define SPDLOG_ROS_GENERAL_STREAM_SKIPFIRST(severity, stream_arg) \
   do { \
-    SPDLOG_ROS_LOGGING_ENABLED("", severity) \
+    SPDLOG_ROS_LOGGING_ENABLED(SPDLOG_ROS_DEFAULT_NAME, severity) \
     if (SPDLOG_ROS_UTILS_UNLIKELY(__spdlog_ros_logging_enabled_log_location.enabled)) \
     { \
       std::stringstream spllog_ros_stream_ss_; \
       spllog_ros_stream_ss_ << stream_arg; \
       SPDLOG_ROS_UTILS_LOG_SKIPFIRST( \
-        "", \
+        SPDLOG_ROS_DEFAULT_NAME, \
         severity, \
         "{}", spllog_ros_stream_ss_.str().c_str()); \
     } \
@@ -634,13 +634,13 @@
  */
 #define SPDLOG_ROS_GENERAL_STREAM_SKIPFIRST_NAMED(severity, name, stream_arg) \
   do { \
-    SPDLOG_ROS_LOGGING_ENABLED(name, severity) \
+    SPDLOG_ROS_LOGGING_ENABLED(SPDLOG_ROS_NAMED_LOGGER_NAME(name), severity) \
     if (SPDLOG_ROS_UTILS_UNLIKELY(__spdlog_ros_logging_enabled_log_location.enabled)) \
     { \
       std::stringstream spllog_ros_stream_ss_; \
       spllog_ros_stream_ss_ << stream_arg; \
       SPDLOG_ROS_UTILS_LOG_SKIPFIRST( \
-        name, \
+        SPDLOG_ROS_NAMED_LOGGER_NAME(name), \
         severity, \
         "{}", spllog_ros_stream_ss_.str().c_str()); \
     } \
@@ -659,13 +659,13 @@
  */
 #define SPDLOG_ROS_GENERAL_STREAM_THROTTLE(severity, duration, stream_arg) \
   do { \
-    SPDLOG_ROS_LOGGING_ENABLED("", severity) \
+    SPDLOG_ROS_LOGGING_ENABLED(SPDLOG_ROS_DEFAULT_NAME, severity) \
     if (SPDLOG_ROS_UTILS_UNLIKELY(__spdlog_ros_logging_enabled_log_location.enabled)) \
     { \
       std::stringstream spllog_ros_stream_ss_; \
       spllog_ros_stream_ss_ << stream_arg; \
       SPDLOG_ROS_UTILS_LOG_THROTTLE( \
-        "", \
+        SPDLOG_ROS_DEFAULT_NAME, \
         severity, \
         spdlog_ros::LoggerManager::GetLoggerManager()->getTimePointCallback(), \
         duration, \
@@ -687,13 +687,13 @@
  */
 #define SPDLOG_ROS_GENERAL_STREAM_THROTTLE_NAMED(severity, duration, name, stream_arg) \
   do { \
-    SPDLOG_ROS_LOGGING_ENABLED(name, severity) \
+    SPDLOG_ROS_LOGGING_ENABLED(SPDLOG_ROS_NAMED_LOGGER_NAME(name), severity) \
     if (SPDLOG_ROS_UTILS_UNLIKELY(__spdlog_ros_logging_enabled_log_location.enabled)) \
     { \
       std::stringstream spllog_ros_stream_ss_; \
       spllog_ros_stream_ss_ << stream_arg; \
       SPDLOG_ROS_UTILS_LOG_THROTTLE( \
-        name, \
+        SPDLOG_ROS_NAMED_LOGGER_NAME(name), \
         severity, \
         spdlog_ros::LoggerManager::GetLoggerManager()->getTimePointCallback(), \
         duration, \
@@ -715,13 +715,13 @@
  */
 #define SPDLOG_ROS_GENERAL_STREAM_SKIPFIRST_THROTTLE(severity, duration, stream_arg) \
   do { \
-    SPDLOG_ROS_LOGGING_ENABLED("", severity) \
+    SPDLOG_ROS_LOGGING_ENABLED(SPDLOG_ROS_DEFAULT_NAME, severity) \
     if (SPDLOG_ROS_UTILS_UNLIKELY(__spdlog_ros_logging_enabled_log_location.enabled)) \
     { \
       std::stringstream spllog_ros_stream_ss_; \
       spllog_ros_stream_ss_ << stream_arg; \
       SPDLOG_ROS_UTILS_LOG_SKIPFIRST_THROTTLE( \
-        "", \
+        SPDLOG_ROS_DEFAULT_NAME, \
         severity, \
         spdlog_ros::LoggerManager::GetLoggerManager()->getTimePointCallback(), \
         duration, \
@@ -744,13 +744,13 @@
  */
 #define SPDLOG_ROS_GENERAL_STREAM_SKIPFIRST_THROTTLE_NAMED(severity, duration, name, stream_arg) \
   do { \
-    SPDLOG_ROS_LOGGING_ENABLED(name, severity) \
+    SPDLOG_ROS_LOGGING_ENABLED(SPDLOG_ROS_NAMED_LOGGER_NAME(name), severity) \
     if (SPDLOG_ROS_UTILS_UNLIKELY(__spdlog_ros_logging_enabled_log_location.enabled)) \
     { \
       std::stringstream spllog_ros_stream_ss_; \
       spllog_ros_stream_ss_ << stream_arg; \
       SPDLOG_ROS_UTILS_LOG_SKIPFIRST_THROTTLE( \
-        name, \
+        SPDLOG_ROS_NAMED_LOGGER_NAME(name), \
         severity, \
         spdlog_ros::LoggerManager::GetLoggerManager()->getTimePointCallback(), \
         duration, \

--- a/include/spdlog_ros/logging_util_macros.hpp
+++ b/include/spdlog_ros/logging_util_macros.hpp
@@ -73,4 +73,19 @@ typedef uint64_t spdlog_ros_utils_ret_t;
 #define SPDLOG_ROS_UTILS_CAST_DURATION(x) ((spdlog_ros_utils_duration_value_t)x)
 #endif
 
+#ifdef ROS_PACKAGE_NAME
+#define SPDLOG_ROS_PACKAGE_NAME ROS_PACKAGE_NAME
+#else
+#define SPDLOG_ROS_PACKAGE_NAME "unknown_package"
+#endif
+
+#define SPDLOG_ROS_NAME_PREFIX SPDLOG_ROS_PACKAGE_NAME
+#define SPDLOG_ROS_DEFAULT_NAME SPDLOG_ROS_NAME_PREFIX
+/**
+ * \def SPDLOG_ROS_NAMED_LOGGER_NAME
+ * Need to convert SPDLOG_ROS_NAME_PREFIX together with the dot to a std::string such that the named logger name can be
+ * a regular c-string as well as std::string
+ */
+#define SPDLOG_ROS_NAMED_LOGGER_NAME(name) std::string(SPDLOG_ROS_NAME_PREFIX ".") + name
+
 #endif //SPDLOG_ROS_LOGGING_UTIL_MACROS_HPP

--- a/src/example_ros.cpp
+++ b/src/example_ros.cpp
@@ -34,7 +34,7 @@ int mainWithRos(int argc, char** argv)
   // // export SPDLOG_LEVEL="off,spdlog_ros_example.named_logger1=debug,spdlog_ros_example.named_logger2=info"
   // spdlog::cfg::load_env_levels();
 
-  // Set the root logger name, all loggers will be prefixed with this name (e.g. your ros node name)
+  // Set the base logger name, all loggers will be prefixed with this name (e.g. your ros node name)
   // If none is set, the logger name is directly the full logger name given at creation
   // Note that this should happen before all other calls to spdlog_ros such that the file name for logging
   // is set properly (otherwise the file name is just "~/logfiles/_yyyy-mm-ddThh:mm:ssZ.log")
@@ -54,7 +54,7 @@ int mainWithRos(int argc, char** argv)
   // create loggers on the fly when used with a new logger name
 
   // // Create an async logger that logs to the console, file and ROS (note that the logger name is prefixed
-  // // with the root logger name)
+  // // with the base logger name)
   // auto logger = spdlog_ros::LoggerManager::GetLoggerManager()->createAsyncLogger("my_logger");
   // // if one wants to use this logger everywhere, it needs to be registered to spdlog because
   // // otherwise the macros won't find it

--- a/src/example_ros2.cpp
+++ b/src/example_ros2.cpp
@@ -34,7 +34,7 @@ int mainWithRos(int argc, char** argv)
   // // export SPDLOG_LEVEL="off,spdlog_ros_example.named_logger1=debug,spdlog_ros_example.named_logger2=info"
   // spdlog::cfg::load_env_levels();
 
-  // Set the root logger name, all loggers will be prefixed with this name (e.g. your ros node name)
+  // Set the base logger name, all loggers will be prefixed with this name (e.g. your ros node name)
   // If none is set, the logger name is directly the full logger name given at creation
   // Note that this should happen before all other calls to spdlog_ros such that the file name for logging
   // is set properly (otherwise the file name is just "~/logfiles/_yyyy-mm-ddThh:mm:ssZ.log")
@@ -54,7 +54,7 @@ int mainWithRos(int argc, char** argv)
   // create loggers on the fly when used with a new logger name
 
   // // Create an async logger that logs to the console, file and ROS (note that the logger name is prefixed
-  // // with the root logger name)
+  // // with the base logger name)
   // auto logger = spdlog_ros::LoggerManager::GetLoggerManager()->createAsyncLogger("my_logger");
   // // if one wants to use this logger everywhere, it needs to be registered to spdlog because
   // // otherwise the macros won't find it

--- a/src/logger_manager.cpp
+++ b/src/logger_manager.cpp
@@ -21,6 +21,8 @@ std::shared_ptr<LoggerManager> LoggerManager::instance_ = nullptr;
 void LoggerManager::CreateLoggerManager(const std::string& base_logger_name)
 {
   // Create LoggerManager only if not yet existing such that multiple calls do not have any side effects
+  static std::mutex create_logger_mutex;
+  const std::lock_guard<std::mutex> lock(create_logger_mutex);
   if (!instance_)
   {
     instance_ = std::shared_ptr<LoggerManager>(new LoggerManager(base_logger_name));

--- a/src/ros2_logging.cpp
+++ b/src/ros2_logging.cpp
@@ -65,9 +65,11 @@ void SetUpROSLogging(rclcpp::Node::SharedPtr node)
   // export SPDLOG_LEVEL="off,node_name.named_logger1=debug,node_name.named_logger2=info"
   spdlog::cfg::load_env_levels();
 
-  // Set the root logger name, all loggers will be prefixed with this name
-  // Note that the file name for logging is "~/logfiles/{root_logger_name}_yyyy-mm-ddThh:mm:ssZ.log")
-  spdlog_ros::LoggerManager::CreateLoggerManager(node->get_name());
+  // Set the base logger name, all loggers will be prefixed with this name
+  // Note that the file name for logging is "~/logfiles/{cleaned_base_logger_name}_yyyy-mm-ddThh:mm:ssZ.log")
+  // where cleaned_base_logger_name is the base logger name with leading slash removed and all other slashes
+  // replaced with underscore
+  spdlog_ros::LoggerManager::CreateLoggerManager(node->get_fully_qualified_name());
 
   // Set up spdlog_ros to use the ROS time (instead of the default std::chrono time)
   spdlog_ros::UseROSTime(node->get_clock());

--- a/src/ros_logging.cpp
+++ b/src/ros_logging.cpp
@@ -62,15 +62,11 @@ void SetUpROSLogging()
   // export SPDLOG_LEVEL="off,node_name.named_logger1=debug,node_name.named_logger2=info"
   spdlog::cfg::load_env_levels();
 
-  // Set the root logger name, all loggers will be prefixed with this name
-  // Note that the file name for logging is "~/logfiles/{root_logger_name}_yyyy-mm-ddThh:mm:ssZ.log")
-  std::string full_node_name = ros::this_node::getName();
-  // remove leading slash if existing
-  if (!full_node_name.empty() && full_node_name[0] == '/')
-  {
-    full_node_name.erase(0, 1); 
-  }
-  spdlog_ros::LoggerManager::CreateLoggerManager(full_node_name);
+  // Set the base logger name, all loggers will be prefixed with this name
+  // Note that the file name for logging is "~/logfiles/{cleaned_base_logger_name}_yyyy-mm-ddThh:mm:ssZ.log")
+  // where cleaned_base_logger_name is the base logger name with leading slash removed and all other slashes
+  // replaced with underscore
+  spdlog_ros::LoggerManager::CreateLoggerManager(ros::this_node::getName());
 
   // Set up spdlog_ros to use the ROS time (instead of the default std::chrono time)
   spdlog_ros::UseROSTime();


### PR DESCRIPTION
- create logger manager only once such that multiple calls to CreateLoggerManager (or SetUpROSLogging) does not have any effect
- adapt logger name (shown in stdout and rosout) and logging file name such that fully qualified node name and the package name is used
  - for example: 
    - node name: `/namespace1/namespace2/node_name`
    - package: `my_great_package`
    - logger name: `/namespace1/namespace2/node_name.my_great_package`
    - logging file name: `namespace1_namespace2_node_name_yyyy-mm-ddThh:mm:ssZ.log` where the time is in UTC (indicated by trailing `Z` character)
    - If there is a named logger, then the named logger is prepended to the logger name with a dot e.g. `/namespace1/namespace2/node_name.my_great_package.named_logger`